### PR TITLE
replaced WCT.DataGrid with WinUI.TableView

### DIFF
--- a/WinUI3Localizer.SampleApp/ShellPage.xaml
+++ b/WinUI3Localizer.SampleApp/ShellPage.xaml
@@ -2,7 +2,7 @@
     x:Class="WinUI3Localizer.SampleApp.ShellPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:tv="using:WinUI.TableView"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:l="using:WinUI3Localizer"
     xmlns:local="using:WinUI3Localizer.SampleApp"
@@ -76,26 +76,22 @@
                             Grid.Row="0"
                             Style="{StaticResource SubtitleTextBlockStyle}"
                             Text="String resources" />
-                        <controls:DataGrid
-                            x:Name="LanguageDictionaryDataGridControl"
+                        <tv:TableView 
+                            x:Name="LanguageDictionaryTableViewControl"
                             Grid.Row="1"
                             AutoGenerateColumns="False"
-                            CanUserReorderColumns="False"
+                            SelectionUnit="Row"
+                            ShowExportOptions="True"
                             IsReadOnly="True">
-                            <controls:DataGrid.Resources>
-                                <Color x:Key="DataGridColumnHeaderBackgroundColor">Transparent</Color>
-                            </controls:DataGrid.Resources>
-                            <controls:DataGrid.Columns>
-                                <controls:DataGridTextColumn
+                            <tv:TableView.Columns>
+                                <tv:TableViewTextColumn 
                                     Binding="{Binding StringResourceItemName}"
-                                    FontSize="12"
                                     Header="Name" />
-                                <controls:DataGridTextColumn
+                                <tv:TableViewTextColumn 
                                     Binding="{Binding Value}"
-                                    FontSize="12"
                                     Header="Value" />
-                            </controls:DataGrid.Columns>
-                        </controls:DataGrid>
+                            </tv:TableView.Columns>
+                        </tv:TableView>
                     </Grid>
                 </SplitView.Pane>
                 <Grid ColumnDefinitions="*,Auto">

--- a/WinUI3Localizer.SampleApp/ShellPage.xaml
+++ b/WinUI3Localizer.SampleApp/ShellPage.xaml
@@ -81,16 +81,15 @@
                             Grid.Row="1"
                             AutoGenerateColumns="False"
                             SelectionUnit="Row"
-                            ShowExportOptions="True">
+                            ShowExportOptions="True"
+                            IsReadOnly="True">
                             <tv:TableView.Columns>
                                 <tv:TableViewTextColumn 
                                     Binding="{Binding StringResourceItemName}"
-                                    Header="Name"
-                                    IsReadOnly="True" />
+                                    Header="Name" />
                                 <tv:TableViewTextColumn 
                                     Binding="{Binding Value}"
-                                    Header="Value" 
-                                    IsReadOnly="False" />
+                                    Header="Value" />
                             </tv:TableView.Columns>
                         </tv:TableView>
                     </Grid>

--- a/WinUI3Localizer.SampleApp/ShellPage.xaml
+++ b/WinUI3Localizer.SampleApp/ShellPage.xaml
@@ -81,15 +81,16 @@
                             Grid.Row="1"
                             AutoGenerateColumns="False"
                             SelectionUnit="Row"
-                            ShowExportOptions="True"
-                            IsReadOnly="True">
+                            ShowExportOptions="True">
                             <tv:TableView.Columns>
                                 <tv:TableViewTextColumn 
                                     Binding="{Binding StringResourceItemName}"
-                                    Header="Name" />
+                                    Header="Name"
+                                    IsReadOnly="True" />
                                 <tv:TableViewTextColumn 
                                     Binding="{Binding Value}"
-                                    Header="Value" />
+                                    Header="Value" 
+                                    IsReadOnly="False" />
                             </tv:TableView.Columns>
                         </tv:TableView>
                     </Grid>

--- a/WinUI3Localizer.SampleApp/ShellPage.xaml.cs
+++ b/WinUI3Localizer.SampleApp/ShellPage.xaml.cs
@@ -28,7 +28,7 @@ public sealed partial class ShellPage : Page
             .GetItems()
             .ToList();
 
-        this.LanguageDictionaryDataGridControl.ItemsSource = LanguageDictionaryItems;
+        this.LanguageDictionaryTableViewControl.ItemsSource = LanguageDictionaryItems;
     }
 
     private List<LanguageItem> AvailableLanguages { get; set; }
@@ -70,8 +70,8 @@ public sealed partial class ShellPage : Page
             string uid = Uids.GetUid(dependencyObject);
             if (LanguageDictionaryItems.Where(x => x.Uid == uid).FirstOrDefault() is LanguageDictionary.Item item)
             {
-                this.LanguageDictionaryDataGridControl.SelectedItem = item;
-                this.LanguageDictionaryDataGridControl.ScrollIntoView(item, null);
+                this.LanguageDictionaryTableViewControl.SelectedItem = item;
+                this.LanguageDictionaryTableViewControl.ScrollIntoView(item);
                 e.Handled = true;
             }
         }
@@ -87,7 +87,7 @@ public sealed partial class ShellPage : Page
                 .GetCurrentLanguageDictionary()
                 .GetItems()
                 .ToList();
-            this.LanguageDictionaryDataGridControl.ItemsSource = LanguageDictionaryItems;
+            this.LanguageDictionaryTableViewControl.ItemsSource = LanguageDictionaryItems;
         }
     }
 }

--- a/WinUI3Localizer.SampleApp/WinUI3Localizer.SampleApp.csproj
+++ b/WinUI3Localizer.SampleApp/WinUI3Localizer.SampleApp.csproj
@@ -17,7 +17,7 @@
     <WindowsPackageType>None</WindowsPackageType>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     -->
-    <WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.19041.56</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,12 +45,11 @@
   <ItemGroup>
     <PackageReference Include="ColorCode.WinUI" Version="2.0.15" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.1" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
     <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
@@ -58,6 +57,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="WinUI3Localizer" Version="2.3.0-alpha" />
+    <PackageReference Include="WinUI.TableView" Version="1.3.1" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR replaces [CommunityToolkit.WinUI.UI.Controls.DataGrid](https://www.nuget.org/packages/CommunityToolkit.WinUI.UI.Controls.DataGrid) with [WinUI.TableView](https://www.nuget.org/packages/WinUI.TableView). This will allow users to export, sort and filter the resource values.

after 
![image](https://github.com/user-attachments/assets/542f9f4a-2f11-4014-9ba6-400652db8753)

before
![image](https://github.com/user-attachments/assets/b7c39704-1cad-416d-80f9-4e4580cf12cf)