### PR TITLE
Fixed type mismatch in Bold action and missing operator in sample app LocalizationActionsPage

### DIFF
--- a/WinUI3Localizer.SampleApp/LocalizationActionsPage.xaml
+++ b/WinUI3Localizer.SampleApp/LocalizationActionsPage.xaml
@@ -33,7 +33,7 @@ ILocalizer localizer = await new LocalizerBuilder()
     .AddLocalizationAction(
         new LocalizationActions.ActionItem(typeof(Hyperlink), args =>
         {
-            if (args.DependencyObject is Hyperlink target  target.Inlines.Count is 0)
+            if (args.DependencyObject is Hyperlink target &amp;&amp; target.Inlines.Count is 0)
             {
                 target.Inlines.Clear();
                 target.Inlines.Add(new Run() { Text = args.Value });

--- a/WinUI3Localizer/LocalizationActions.cs
+++ b/WinUI3Localizer/LocalizationActions.cs
@@ -30,7 +30,7 @@ public static class LocalizationActions
         }),
         new ActionItem(typeof(Bold), arguments =>
         {
-            if (arguments.DependencyObject is Hyperlink target)
+            if (arguments.DependencyObject is Bold target)
             {
                 target.Inlines.Clear();
                 target.Inlines.Add(new Run() { Text = arguments.Value });


### PR DESCRIPTION
Two small bug fixes in LocalizationActions. One in the library and one in the sample app.

# Changes

## 1. `WinUI3Localizer/LocalizationActions.cs`

The `Bold` ActionItem checks `arguments.DependencyObject is Hyperlink target` instead of `is Bold target`. 
Because of it the Bold action never executes, since the type check always fails.

## 2. `WinUI3Localizer.SampleApp/LocalizationActionsPage.xaml`

The C# sample code block is missing the `&&` operator:

`if (args.DependencyObject is Hyperlink target  target.Inlines.Count is 0)`

should be:

`if (args.DependencyObject is Hyperlink target && target.Inlines.Count is 0)`